### PR TITLE
Fix top padding

### DIFF
--- a/LightboxOverlay.js
+++ b/LightboxOverlay.js
@@ -23,7 +23,7 @@ var {
 var WINDOW_HEIGHT = Dimensions.get('window').height;
 var WINDOW_WIDTH = Dimensions.get('window').width;
 var DRAG_DISMISS_THRESHOLD = 150;
-var STATUS_BAR_OFFSET = (Platform.OS === 'android' ? -25 : 0);
+var STATUS_BAR_OFFSET = 0;
 
 var LightboxOverlay = React.createClass({
   propTypes: {


### PR DESCRIPTION
The top padding was off.  We shouldn't be accounting for the status bar offset, because doing so moves the screen too high up.

Before:
![screenshot-2017-02-09_17 33 36 9](https://cloud.githubusercontent.com/assets/19673711/22811587/8df86476-eef4-11e6-9013-01f5877d5a32.png)

After (notice the less black at the bottom):
![screenshot-2017-02-09_17 32 50 537](https://cloud.githubusercontent.com/assets/19673711/22811586/8de5910c-eef4-11e6-9067-d8998d7a4c9f.png)

